### PR TITLE
add user and mode to database properties

### DIFF
--- a/manifests/db/config.pp
+++ b/manifests/db/config.pp
@@ -11,6 +11,9 @@ class teamcity::db::config inherits ::teamcity::params {
   file { "${::teamcity::params::teamcity_data_path}/config/database.properties":
     ensure  => 'present',
     content => template("teamcity/${db_type}.database.properties.erb")
+    owner   => 'teamcity'
+    group   => 'teamcity'
+    mode    => '0640'
   } ~>
 
   Service['teamcity']


### PR DESCRIPTION
Right now this file belongs to root and is readable by everyone. Since this file contains a password, it should not be readable by everyone.