### PR TITLE
Managing home dir for teamcity user

### DIFF
--- a/manifests/prepare.pp
+++ b/manifests/prepare.pp
@@ -9,6 +9,7 @@ class teamcity::prepare inherits teamcity::params  {
     ensure  => 'present',
     gid     => 'teamcity',
     uid     => '2158',
+    managehome => true
   }
 
   file { '/opt/teamcity-sources':


### PR DESCRIPTION
Sometimes TC needs home directory, e.g. for .ivy or .sbt